### PR TITLE
Solves WS client reconnect error

### DIFF
--- a/src/C-DEngine/C-DCommunication/Protocols/HTTP/Service/cde_MidiHttpService.cs
+++ b/src/C-DEngine/C-DCommunication/Protocols/HTTP/Service/cde_MidiHttpService.cs
@@ -6,6 +6,7 @@ using nsCDEngine.BaseClasses;
 using System;
 using System.Net;
 using System.Net.Sockets;
+using System.Threading;
 
 namespace nsCDEngine.Communication.HttpService
 {
@@ -158,25 +159,27 @@ namespace nsCDEngine.Communication.HttpService
         public void ShutDown()
         {
             IsActive = false;
-            if (mHttpListener != null)
+
+            var httpListener = Interlocked.Exchange(ref mHttpListener, null);
+            if (httpListener != null)
             {
                 try
                 {
                     TheBaseAssets.MySYSLOG.WriteToLog(4345, TSM.L(eDEBUG_LEVELS.VERBOSE) ? null : new TSM("HttpMidiServer", "Stopping Http Listener", eMsgLevel.l6_Debug));
-                    mHttpListener.Stop();
-                    mHttpListener.Prefixes.Remove(MyHttpUrl);
+                    httpListener.Stop();
+                    httpListener.Prefixes.Remove(MyHttpUrl);
                 }
                 catch
                 {
                     //Ignored
                 }
-                mHttpListener = null;
             }
-            if (mListener != null)
+
+            var listener = Interlocked.Exchange(ref mListener, null);
+            if (listener != null)
             {
                 TheBaseAssets.MySYSLOG.WriteToLog(4345, TSM.L(eDEBUG_LEVELS.VERBOSE) ? null : new TSM("HttpMidiServer", "Stopping Listener", eMsgLevel.l6_Debug));
-                mListener.Stop();
-                mListener = null;
+                listener.Stop();
             }
         }
     }

--- a/src/C-DEngine/C-DCommunication/Protocols/WS/cde_WSCommon.cs
+++ b/src/C-DEngine/C-DCommunication/Protocols/WS/cde_WSCommon.cs
@@ -22,7 +22,7 @@ namespace nsCDEngine.Communication
         protected TheRequestData MySessionRequestData;
         protected bool CloseFired;
         protected bool IsClient = false;
-        protected readonly CancellationTokenSource mCancelToken=new ();
+        protected CancellationTokenSource mCancelToken = new();
 
         protected ManualResetEventSlim mre; //NEW:V3BETA2: Was AutoReset Event
         internal bool ProcessingAllowed
@@ -83,8 +83,9 @@ namespace nsCDEngine.Communication
                 eventConnected = null;
                 if (mre != null) mre.Dispose();
                 mre = null;
-                if (mCancelToken != null)
-                    mCancelToken.Cancel();
+                mCancelToken?.Cancel();
+                mCancelToken?.Dispose();
+                mCancelToken = null;
                 iDispose();
             }
         }

--- a/src/C-DEngine/C-DCommunication/Protocols/WS/cde_WSProcessor.cs
+++ b/src/C-DEngine/C-DCommunication/Protocols/WS/cde_WSProcessor.cs
@@ -90,6 +90,8 @@ namespace nsCDEngine.Communication
                 CloseFired = false;
                 ConnectSuccess = false;
                 ClientWebSocket wsClientSocket = new ();
+                mCancelToken = new();
+
                 websocket = wsClientSocket;
                 if (!string.IsNullOrEmpty(TheBaseAssets.MyServiceHostInfo.ProxyUrl))
                 {


### PR DESCRIPTION
In case the connection to the cloud could not be established or gets broken, the CDE WS client was not able to reconnect again because the CancellationToken was already canceled by the previous connection break.

The fix recreates the token before the reconnect is started.

In addition there was a race condition in the Shutdown of the MidiHttpService that leads to a NullReferenceException in CDE shutdown.