### PR TITLE
QueuedSender SendBuffer optimization and more

### DIFF
--- a/src/C-DEngine/C-DCommunication/cdeQueuedSender/cde_QueuedSenderWS.cs
+++ b/src/C-DEngine/C-DCommunication/cdeQueuedSender/cde_QueuedSenderWS.cs
@@ -8,7 +8,7 @@ using System;
 using System.Threading;
 using nsCDEngine.ISM;
 using System.Text;
-using nsCDEngine.Security;
+
 // ReSharper disable All
 
 namespace nsCDEngine.Communication
@@ -85,7 +85,7 @@ namespace nsCDEngine.Communication
             mre = new ManualResetEvent(false);
 
             CloudCounter++;
-            StringBuilder tSendBufferStr = new StringBuilder(TheBaseAssets.MyServiceHostInfo?.IsMemoryOptimized == true ? 1024 : TheBaseAssets.MAX_MessageSize[(int)MyTargetNodeChannel.SenderType] * 2);
+            StringBuilder tSendBufferStr = null;
             int QDelay = TheCommonUtils.CInt(TheBaseAssets.MySettings.GetSetting("ThrottleWS"));
             if (QDelay < 2) QDelay = 2;
             if (MyTargetNodeChannel.SenderType == cdeSenderType.CDE_JAVAJASON && TheBaseAssets.MyServiceHostInfo.WsJsThrottle > QDelay)
@@ -106,6 +106,8 @@ namespace nsCDEngine.Communication
                         }
                         if (MyTargetNodeChannel.MySessionState == null && !IsConnecting && MyCoreQueue.Count > 0)
                             break;
+
+                        tSendBufferStr = null;
                         mre.WaitOne(QDelay);
                     }
                     if (!TheBaseAssets.MasterSwitch || !IsAlive || !MyWebSocketProcessor.IsActive || MyTargetNodeChannel.MySessionState == null)
@@ -118,11 +120,8 @@ namespace nsCDEngine.Communication
                     int MCQCount = 0;
                     int IsBatchOn = 0;
                     int FinalCnt = 0;
-#if CDE_NET35
-                    tSendBufferStr = new StringBuilder(TheBaseAssets.MAX_MessageSize[(int)MyTargetNodeChannel.SenderType] * 2);
-#else
-                    tSendBufferStr.Clear();
-#endif
+
+                    tSendBufferStr ??= new StringBuilder(TheBaseAssets.MyServiceHostInfo?.IsMemoryOptimized == true ? 1024 : TheBaseAssets.MAX_MessageSize[(int)MyTargetNodeChannel.SenderType] * 2);
                     tSendBufferStr.Append("[");
                     do
                     {
@@ -242,11 +241,13 @@ namespace nsCDEngine.Communication
                     if (FinalCnt > 1)
                         TheBaseAssets.MySYSLOG.WriteToLog(235, TSM.L(eDEBUG_LEVELS.FULLVERBOSE) ? null : new TSM("WSQueuedSender", $"Batched:{FinalCnt}", eMsgLevel.l3_ImportantMessage));
 
-                    if (!cdeSenderType.CDE_JAVAJASON.Equals(MyTargetNodeChannel.SenderType))
+                    if (cdeSenderType.CDE_JAVAJASON != MyTargetNodeChannel.SenderType)
                         MyWebSocketProcessor.PostToSocket(null, TheCommonUtils.cdeCompressString(tSendBufferStr.ToString()), true, false);
                     else
                         MyWebSocketProcessor.PostToSocket(null, TheCommonUtils.CUTF8String2Array(tSendBufferStr.ToString()), false, false);
                     IsInWSPost = false;
+
+                    tSendBufferStr.Clear();
                 }
                 TheBaseAssets.MySYSLOG.WriteToLog(235, TSM.L(eDEBUG_LEVELS.ESSENTIALS) ? null : new TSM("WSQueuedSender", $"WSQSenderThread was closed for {MyTargetNodeChannel?.ToMLString()} IsAlive:{IsAlive} MyWSProccAlive:{(MyWebSocketProcessor == null ? "Is Null" : MyWebSocketProcessor?.IsActive.ToString())},SessionState:{(MyTargetNodeChannel?.MySessionState != null)} IsConnecting:{IsConnecting} IsConnected:{IsConnected}", eMsgLevel.l1_Error));
             }

--- a/src/cdeASPNet/cdeASPNetCommon.cs
+++ b/src/cdeASPNet/cdeASPNetCommon.cs
@@ -70,7 +70,7 @@ namespace cdeASPNetMiddleware
                         string val = co[0];
                         string pat = "/"; if (co.Length > 1) pat = co[1];
                         string dom = null; if (co.Length > 2) dom = co[2];
-                        var tcooki = new CookieOptions { Path = pat, Domain = dom, Expires = DateTime.MinValue, HttpOnly = true, Secure=true };
+                        var tcooki = new CookieOptions { Path = pat, Domain = dom, Expires = DateTimeOffset.MinValue, HttpOnly = true, Secure=true };
                         if (!tReq.RequestUri.Scheme.Equals("wss", StringComparison.OrdinalIgnoreCase) && !tReq.RequestUri.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase))
                             tcooki.Secure = false; //NOSONAR we do have to support local non-tls clients
                         Response.Cookies.Append(nam, val, tcooki);

--- a/src/cdeASPNet/cdeAspNetWSHandler.cs
+++ b/src/cdeASPNet/cdeAspNetWSHandler.cs
@@ -36,7 +36,7 @@ namespace cdeASPNetMiddleware
             {
                 if (context.WebSockets.IsWebSocketRequest)
                 {
-                    WebSocket webSocket = await context.WebSockets.AcceptWebSocketAsync();
+                    using WebSocket webSocket = await context.WebSockets.AcceptWebSocketAsync();
                     await ProcessWSRequest(context, webSocket);
                     return;
                 }


### PR DESCRIPTION
1. Changed the SendBuffer to only keep its referenced in case that messages where queued in the QueuedSender. Otherwise the SendBuffer will always be kept allocated which results in a steady huge memory consumptions on the CloudGate. The change now allocates the buffer once messages are present in the queue and releases the reference in case no messages must be send.

2. Forced a WebSocket disposal in cdeAspNetWsHandler. Although it should not be possible its a good place to dispose the WebSocket at the place where it was created.

3. Get rid of a System.ArgumentOutOfRangeException in cdeASPNetCommon thrown during the initialization of a DateTimeOffset instance from DateTime.Min.