### PR TITLE
Fix total calculation for non-labeled KPIs

### DIFF
--- a/src/C-DEngine/C-DBaseClasses/cde_KPIs.cs
+++ b/src/C-DEngine/C-DBaseClasses/cde_KPIs.cs
@@ -689,7 +689,7 @@ namespace nsCDEngine.BaseClasses
                         if (!dontComputeTotals)
                         {
                             kpiPropTotal = pThing.GetProperty($"{keyVal.Key}Total", true);
-                            pThing.SetProperty($"{keyVal.Key}Total", (kpiPropTotal.GetValue() as long? ?? 0) + kpi.Value.Value);
+                            pThing.SetProperty($"{keyVal.Key}Total", TheCommonUtils.CDbl(kpiPropTotal.GetValue()) + kpi.Value.Value);
                         }
                     }
 


### PR DESCRIPTION
My last change of the KPI extensions contain an error calculating the values ot the "total KPIs".
The reason is a failed/invalid cast to `long?`.
Fixed that by using `TheCommonUtils.CDbl`.