### PR TITLE
Extend some syslog outputs with scopes

### DIFF
--- a/src/C-DEngine/C-DCommunication/Protocols/WS/cde_WSProcessor.cs
+++ b/src/C-DEngine/C-DCommunication/Protocols/WS/cde_WSProcessor.cs
@@ -300,7 +300,7 @@ namespace nsCDEngine.Communication
                     Debug LogBufferToFile("wsinputbactchedlog.dat", tPostData, 0, tPostData.Length);
 #endif
                     TheCommonUtils.cdeRunAsync("ProcessFromWS", true,
-                        (o) => ProcessIncomingData(null, (byte[]) o, ((byte[]) o).Length), tPostData);
+                        o => ProcessIncomingData(null, (byte[]) o, ((byte[]) o).Length), tPostData);
                 }
             }
             catch (OperationCanceledException)
@@ -313,9 +313,9 @@ namespace nsCDEngine.Communication
                 if (TheBaseAssets.MasterSwitch)
                 {
                     if (eee.Source == "System")
-                        TheBaseAssets.MySYSLOG.WriteToLog(4369, TSM.L(eDEBUG_LEVELS.OFF) ? null : new TSM("ProcessWS", "ProcessWS Loop has failed because WebSocket was closed during ReceiveAsync.", eMsgLevel.l1_Error));
+                        TheBaseAssets.MySYSLOG.WriteToLog(4369, TSM.L(eDEBUG_LEVELS.OFF) ? null : new TSM("ProcessWS", $"ProcessWS Loop has failed because WebSocket was closed during ReceiveAsync. {MyQSender?.MyTargetNodeChannel?.ToMLString()}", eMsgLevel.l1_Error));
                     else
-                        TheBaseAssets.MySYSLOG.WriteToLog(4369, TSM.L(eDEBUG_LEVELS.OFF) ? null : new TSM("ProcessWS", "ProcessWS Loop has failed.", eMsgLevel.l1_Error, eee.ToString()));
+                        TheBaseAssets.MySYSLOG.WriteToLog(4369, TSM.L(eDEBUG_LEVELS.OFF) ? null : new TSM("ProcessWS", $"ProcessWS Loop has failed. {MyQSender?.MyTargetNodeChannel?.ToMLString()}", eMsgLevel.l1_Error, eee.ToString()));
                 }
             }
             TheBaseAssets.MySYSLOG.WriteToLog(4369, TSM.L(eDEBUG_LEVELS.ESSENTIALS) ? null : new TSM("ProcessWS", $"ProcessWS Loop for {OwnerNodeID} has ended. Faulted:{hasFaulted} HasWS:{websocket != null}", eMsgLevel.l3_ImportantMessage));

--- a/src/C-DEngine/C-DCommunication/cdeQueuedSender/cde_QueuedSender.cs
+++ b/src/C-DEngine/C-DCommunication/cdeQueuedSender/cde_QueuedSender.cs
@@ -425,7 +425,7 @@ namespace nsCDEngine.Communication
         {
             if (MyTargetNodeChannel == null) return "No channel, yet";
             DateTimeOffset lastConnectTime = MyLastConnectTime;
-            StringBuilder ret = new ($"<tr><td class=\"cdeLogEntry\" style=\"border-bottom:1px solid rgba(90, 90, 90, 0.25);text-align:left \">{MyTargetNodeChannel.ToMLString(true)}</td>");
+            StringBuilder ret = new ($"<tr><td class=\"cdeLogEntry\" style=\"border-bottom:1px solid rgba(90, 90, 90, 0.25);text-align:left \">{MyTargetNodeChannel.ToMLString(true, false)}</td>");
             if (TheBaseAssets.MyServiceHostInfo.IsCloudService && TheBaseAssets.MyServiceHostInfo.AllowedUnscopedNodes.Contains(MyTargetNodeChannel.cdeMID))
                 ret.Append($"<td class=\"cdeLogEntry\" style=\"text-align:center;\"><span style='color:blue; font-weight:bold'>Cloud2Cloud<br>{(TheBaseAssets.MyServiceHostInfo.CloudToCloudUpstreamOnly?"Diode Mode":"Bi-Directional")}</span></td>");
             else

--- a/src/C-DEngine/C-DCommunication/cdeQueuedSender/cde_QueuedSenderWS.cs
+++ b/src/C-DEngine/C-DCommunication/cdeQueuedSender/cde_QueuedSenderWS.cs
@@ -56,15 +56,16 @@ namespace nsCDEngine.Communication
                 {
                     TheBaseAssets.MySYSLOG.WriteToLog(2371, TSM.L(eDEBUG_LEVELS.ESSENTIALS) ? null : new TSM("WSQueuedSender", $"Starting new WSSender Thread IsAlive:{IsAlive}", eMsgLevel.l4_Message));
                     MyWebSocketProcessor.IsActive = true;
+                    var targetNodeChannel = MyTargetNodeChannel;
                     TheCommonUtils.cdeRunTaskAsync($"WSQSender for ORG:{MyTargetNodeChannel}", o =>
                     {
                         if (IsSenderThreadRunning) return;  //In Case the Thread took longer to create and another one was successful in the meantime
                         TheWSSenderThread();
-                        TheBaseAssets.MySYSLOG.WriteToLog(2372, TSM.L(eDEBUG_LEVELS.ESSENTIALS) ? null : new TSM("WSQueuedSender", $"WSQSenderThread was closed (In RunAync) for {MyTargetNodeChannel?.ToMLString()}", eMsgLevel.l1_Error));
-                        if (MyTargetNodeChannel?.SenderType != cdeSenderType.CDE_CLOUDROUTE)
+                        TheBaseAssets.MySYSLOG.WriteToLog(2372, TSM.L(eDEBUG_LEVELS.ESSENTIALS) ? null : new TSM("WSQueuedSender", $"WSQSenderThread was closed (In RunAync) for {targetNodeChannel?.ToMLString()}", eMsgLevel.l1_Error));
+                        if (targetNodeChannel?.SenderType != cdeSenderType.CDE_CLOUDROUTE)
                         {
-                            TheBaseAssets.MySYSLOG.WriteToLog(236, new TSM("WSQueuedSender", $"WSQSender Thread {MyTargetNodeChannel?.ToMLString()} died", eMsgLevel.l1_Error));
-                            FireSenderProblem(new TheRequestData() { ErrorDescription = $"1309:WSQSender Thread {MyTargetNodeChannel?.ToMLString()} died" });
+                            TheBaseAssets.MySYSLOG.WriteToLog(236, new TSM("WSQueuedSender", $"WSQSender Thread {targetNodeChannel?.ToMLString()} died", eMsgLevel.l1_Error));
+                            FireSenderProblem(new TheRequestData() { ErrorDescription = $"1309:WSQSender Thread {targetNodeChannel?.ToMLString()} died" });
                             IsAlive = false;
                             IsInWSPost = false;
                         }

--- a/src/C-DEngine/C-DCommunication/cde_QueuedSenderRegistry.cs
+++ b/src/C-DEngine/C-DCommunication/cde_QueuedSenderRegistry.cs
@@ -1057,7 +1057,7 @@ namespace nsCDEngine.Communication
             {
                 if ((!bExcludeCloudRoutes || srv.MyTargetNodeChannel.SenderType != cdeSenderType.CDE_BACKCHANNEL) && srv.MySubscriptionContains(pTopic?.Topic, pTopic?.RScopeID, false))
                 {
-                    retList.Add(srv.MyTargetNodeChannel?.ToMLString()); 
+                    retList.Add(srv.MyTargetNodeChannel?.ToMLString(false, false)); 
                 }
             }
             return retList;

--- a/src/C-DEngine/C-DCommunication/cde_Status.cs
+++ b/src/C-DEngine/C-DCommunication/cde_Status.cs
@@ -67,18 +67,18 @@ namespace nsCDEngine.Communication
             return ret.ToString();
         }
 
-        internal static string GetScopeHashML(string hash, string AddToSpan = null)
+        internal static string GetScopeHashML(string hash, string addToSpan = null)
         {
             if (!TheBaseAssets.MyServiceHostInfo.ShowMarkupInLog)
                 return hash;
-            return $"<span onclick=\"if (cdeCSOn) cdeCSOn=null; else cdeCSOn=true;\" onmouseenter=\"cdeColorSpan(this, 'red')\" onmouseleave=\"cdeColorSpan(null)\"  class=\"cdeRSHash\" style='color:orange; font-weight:bold; {(string.IsNullOrEmpty(AddToSpan) ? "" : AddToSpan)}'>{hash}<svg width=\"20\" height=\"20\" data-jdenticon-value=\"{hash}\"></svg></span>";
+            return $"<span onclick=\"if (cdeCSOn) cdeCSOn=null; else cdeCSOn=true;\" onmouseenter=\"cdeColorSpan(this, 'red')\" onmouseleave=\"cdeColorSpan(null)\"  class=\"cdeRSHash\" style='color:orange; font-weight:bold; {(string.IsNullOrEmpty(addToSpan) ? "" : addToSpan)}'>{hash}<svg width=\"20\" height=\"20\" data-jdenticon-value=\"{hash}\"></svg></span>";
         }
-        internal static string GetSScopeHashML(string sScope, string AddToSpan = null)
+        internal static string GetSScopeHashML(string sScope, string addToSpan = null)
         {
             var hash = TheBaseAssets.MyScopeManager.GetRealScopeID(sScope).Substring(0, 4).ToUpper();
             if (!TheBaseAssets.MyServiceHostInfo.ShowMarkupInLog)
                 return hash;
-            return $"<span onclick=\"if (cdeCSOn) cdeCSOn=null; else cdeCSOn=true;\" onmouseenter=\"cdeColorSpan(this, 'red')\" onmouseleave=\"cdeColorSpan(null)\"  class=\"cdeRSHash\" style='color:orange; font-weight:bold; {(string.IsNullOrEmpty(AddToSpan) ? "" : AddToSpan)}'>{hash}<svg width=\"20\" height=\"20\" data-jdenticon-value=\"{hash}\"></svg></span>";
+            return $"<span onclick=\"if (cdeCSOn) cdeCSOn=null; else cdeCSOn=true;\" onmouseenter=\"cdeColorSpan(this, 'red')\" onmouseleave=\"cdeColorSpan(null)\"  class=\"cdeRSHash\" style='color:orange; font-weight:bold; {(string.IsNullOrEmpty(addToSpan) ? "" : addToSpan)}'>{hash}<svg width=\"20\" height=\"20\" data-jdenticon-value=\"{hash}\"></svg></span>";
         }
 
         internal static TheNodeInfoHeader GetInfoHeaderJSON()
@@ -122,7 +122,7 @@ namespace nsCDEngine.Communication
             if (TheBaseAssets.MyServiceHostInfo.ShowMarkupInLog)
                 ret2.Append($"<script>var cdeCSOn; function cdeColorSpan(pContent, pColor) {{ var x = document.getElementsByClassName(\"cdeRSHash\");var i;for (i = 0; i < x.length; i++){{ if (!pContent) {{ if (!cdeCSOn) x[i].style.backgroundColor = \"transparent\"; }} else {{ if (pContent.innerText==x[i].innerText && !cdeCSOn) x[i].style.backgroundColor = pColor; }}}}}}</script>");
             ret2.Append($"<div class=\"cdeInfoBlock\" style=\"width:750px;\"><div class=\"cdeInfoBlockHeader cdeInfoBlockHeaderText\" id=\"nodeInfo\">Node Info</div><table style=\"margin-left:2%\">");
-            ret2.Append($"<tr><th scope=\"rowgroup;\" style=\"background-color:rgba(90,90,90, 0.15); padding:3px; text-align:right; min-width:200px;\">Hosted at:</th><td style=\"border-bottom:1px solid rgba(90, 90, 90, 0.25);padding:3px;text-align:left \">{TheBaseAssets.LocalHostQSender.MyTargetNodeChannel.ToMLString(true)}</td></tr>");
+            ret2.Append($"<tr><th scope=\"rowgroup;\" style=\"background-color:rgba(90,90,90, 0.15); padding:3px; text-align:right; min-width:200px;\">Hosted at:</th><td style=\"border-bottom:1px solid rgba(90, 90, 90, 0.25);padding:3px;text-align:left \">{TheBaseAssets.LocalHostQSender.MyTargetNodeChannel.ToMLString(true, false)}</td></tr>");
             ret2.Append($"<tr><th scope=\"rowgroup;\" style=\"background-color:rgba(90,90,90, 0.15); padding:3px; text-align:right\">Node ID:</th><td style=\"border-bottom:1px solid rgba(90, 90, 90, 0.25);padding:3px;text-align:left \">{TheCommonUtils.GetDeviceIDML(TheBaseAssets.MyServiceHostInfo.MyDeviceInfo.DeviceID)}</td><tr>");
             ret2.Append($"<tr><th scope=\"rowgroup;\" style=\"background-color:rgba(90,90,90, 0.15); padding:3px; text-align:right\">Node Name:</th><td style=\"border-bottom:1px solid rgba(90, 90, 90, 0.25);padding:3px;text-align:left \">{TheBaseAssets.MyServiceHostInfo.NodeName}</td><tr>");
             ret2.Append($"<tr><th scope=\"rowgroup;\" style=\"background-color:rgba(90,90,90, 0.15); padding:3px; text-align:right\">Station Name:</th><td style=\"border-bottom:1px solid rgba(90, 90, 90, 0.25);padding:3px;text-align:left \">{TheBaseAssets.MyServiceHostInfo.MyStationName}</td><tr>");
@@ -321,7 +321,7 @@ namespace nsCDEngine.Communication
                         {
                             curScopesAndSubs.Append("<ul>");
                             foreach (TheChannelInfo tChan in tlst)
-                                curScopesAndSubs.Append("<li>" + tChan.ToMLString() + "</li>");
+                                curScopesAndSubs.Append("<li>" + tChan.ToMLString(false, false) + "</li>");
                             curScopesAndSubs.Append("</ul>");
                         }
                         c2++;

--- a/src/C-DEngine/C-DViewModels/cde_HSI.cs
+++ b/src/C-DEngine/C-DViewModels/cde_HSI.cs
@@ -2173,8 +2173,8 @@ namespace nsCDEngine.ViewModels
         /// Returns a Markup Version of ToString()
         /// </summary>
         /// <returns></returns>
-        public string ToMLString(bool brAll = false)
-            => ToMLString(brAll, true);
+        public string ToMLString(bool BrAll = false)
+            => ToMLString(BrAll, true);
 
         /// <summary>
         /// Returns a Markup Version of ToString()

--- a/src/C-DEngine/C-DViewModels/cde_HSI.cs
+++ b/src/C-DEngine/C-DViewModels/cde_HSI.cs
@@ -13,6 +13,8 @@ using System.Globalization;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using nsCDEngine.Communication;
+
 #pragma warning disable 1591
 
 namespace nsCDEngine.ViewModels
@@ -2171,14 +2173,28 @@ namespace nsCDEngine.ViewModels
         /// Returns a Markup Version of ToString()
         /// </summary>
         /// <returns></returns>
-        public string ToMLString(bool BrAll = false)
+        public string ToMLString(bool brAll = false)
+            => ToMLString(brAll, true);
+
+        /// <summary>
+        /// Returns a Markup Version of ToString()
+        /// </summary>
+        /// <returns></returns>
+        public string ToMLString(bool brAll, bool includeScope)
         {
             if (!TheBaseAssets.MyServiceHostInfo.ShowMarkupInLog)
-                BrAll = false;
+                brAll = false;
+
+            var br = brAll ? "<br>" : " ";
+            var deviceId = TheCommonUtils.GetDeviceIDML(cdeMID);
+
+            var scopes = GetScopes();
+            var scopeHash = !includeScope || string.IsNullOrEmpty(scopes) ? string.Empty : $"{br}[{cdeStatus.GetScopeHashML(scopes)}]";
+
             if (TargetUrl != null && TargetUrl.StartsWith("file"))
-                return $"{SenderType}{(BrAll ? "<br>" : " ")}{TheCommonUtils.GetDeviceIDML(cdeMID)}";
-            else
-                return $"{SenderType}{(BrAll ? "<br>" : " ")}{TheCommonUtils.GetDeviceIDML(cdeMID)}{(BrAll ? "<br>" : " ")}({TargetUrl}){(BrAll ? "<br>" : " ")}{(TruDID != Guid.Empty ? $"TruDID:{TheCommonUtils.GetDeviceIDML(TruDID)}" : "")}";
+                return $"{SenderType}{br}{deviceId}{scopeHash}";
+
+            return $"{SenderType}{br}{deviceId}{br}({TargetUrl}){scopeHash}{br}{(TruDID != Guid.Empty ? $"TruDID:{TheCommonUtils.GetDeviceIDML(TruDID)}" : "")}";
         }
 
         internal TheSessionState MySessionState { get; set; }


### PR DESCRIPTION
Changed the method `TheChannelInfo.ToMLString()` in that way that it is possible to select whether to scopes will be added to the resulting string or not.
The idea is to extend any existing syslog output entry with the scope-id to be able to assign e.g. connection issue log outputs to specific meshes.
With the ability to choose whether to include scopes or not it is possible to keep the format of the `cdestatus.aspx` unchanged and only logs will be extended.