### PR TITLE
Don't compress payload twice when sending messages.

### DIFF
--- a/src/C-DEngine/C-DCommunication/cdeQueuedSender/cde_QueuedSenderWS.cs
+++ b/src/C-DEngine/C-DCommunication/cdeQueuedSender/cde_QueuedSenderWS.cs
@@ -257,13 +257,13 @@ namespace nsCDEngine.Communication
                     {
                         var sendBuffer = TheCommonUtils.cdeCompressString(tSendBufferStr.ToString());
                         sendBufferByteLength = sendBuffer.Length;
-                        MyWebSocketProcessor.PostToSocket(null, TheCommonUtils.cdeCompressString(tSendBufferStr.ToString()), true, false);
+                        MyWebSocketProcessor.PostToSocket(null, sendBuffer, true, false);
                     }
                     else
                     {
                         var sendBuffer = TheCommonUtils.CUTF8String2Array(tSendBufferStr.ToString());
                         sendBufferByteLength = sendBuffer.Length;
-                        MyWebSocketProcessor.PostToSocket(null, TheCommonUtils.CUTF8String2Array(tSendBufferStr.ToString()), false, false);
+                        MyWebSocketProcessor.PostToSocket(null, sendBuffer, false, false);
                     }
 
                     if (TheCDEKPIs.EnableKpis && sendBufferByteLength > 0)


### PR DESCRIPTION
While running some performance tests, I found that the message payload was compressed twice before sending which increased the CPU-load.

This PR solves that issue.